### PR TITLE
Proposed changes to Controled Vocabulary text and basisOfRecord example. 

### DIFF
--- a/dimensions-and-criteria.md
+++ b/dimensions-and-criteria.md
@@ -71,7 +71,6 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 
 | ID | Terms | Comments |
 | ---|---------- | ------------- |
-| CONFORMITY_DATATYPE_EVENT_DATE | `eventDate` | date, including partial date and date range |
 | CONFORMITY_DATATYPE_YEAR | `year` | integer |
 | CONFORMITY_DATATYPE_MONTH | `month` | integer  |
 | CONFORMITY_DATATYPE_DAY | `day` | integer |
@@ -82,7 +81,9 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 
 ### Data format
 
-?
+| ID | Terms | Comments |
+| ---|---------- | ------------- |
+| CONFORMITY_DATAFORMAT_EVENT_DATE | `dwc:eventDate` | Format conforms to recommended best practice "Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)." See: [ISO date](https://en.wikipedia.org/wiki/Iso_date), this can include partial date and date range. |
 
 ## 4. Likeliness
 
@@ -97,11 +98,11 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 | LIKELINESS_COORDINATES_DIGIT_DISTRIBUTION | `decimalLatitude`, `decimalLongitude` | The decimal part in the range `0.0-0.6` is not overrepresented | dataset | Symptom of incorrect conversion from a DMS coordinates |
  
 ### 4.2 Dates
-| ID | Terms | Check |
-| ---|------ | ----- |
-| LIKELINESS_DATES_EVENT_SEQUENCE |`eventDate`,`year`,`month`,`day`,`dateIdentified`,`dcterms:modified`,`georeferencedDate` | `eventDate` or `year`,`month`,`day` is before `dateIdentified`, `dcterms:modified`, `georeferencedDate` |
-| LIKELINESS_DATES_EVENT |`eventDate`, `dateIdentified` | Are after 1600 and before the current date |
-| LIKELINESS_DATES_COMPUTER |`dcterms:modified` | Is after 1970 and before the current date |
+| ID | Terms | Check | Comment |
+| ---|------ | ----- | ------- |
+| LIKELINESS_DATES_EVENT_SEQUENCE |`eventDate`,`year`,`month`,`day`,`dateIdentified`,`dcterms:modified`,`georeferencedDate` | `eventDate` or `year`,`month`,`day` is before `dateIdentified`, `dcterms:modified`, `georeferencedDate` | Assuming the eventDate, year, month and day are properties of a dwc:Occurrence and are thus the date recorded. |
+| LIKELINESS_DATES_EVENT |`eventDate`, `dateIdentified` | Are after 1600 and before the current date | Assuming the eventDate is a property of a dwc:Occurrence and is thus the date recorded. |
+| LIKELINESS_DATES_COMPUTER |`dcterms:modified` | Is after 1970 and before the current date | Assumes that the resource is electronic.  |
 
 ## 5. Consistency
 
@@ -111,7 +112,7 @@ Agreement/accordance with characteristics previously shown or stated. Absence of
 
 | ID | Terms | Comments |
 | ---|------------- | ------------- |
-| CONCISTENCY_EVENT_DATE | [eventDate](http://rs.tdwg.org/dwc/terms/eventDate), [year](http://rs.tdwg.org/dwc/terms/year), [month](http://rs.tdwg.org/dwc/terms/month), [day](http://rs.tdwg.org/dwc/terms/day) |  |
+| CONCISTENCY_EVENT_DATE | [eventDate](http://rs.tdwg.org/dwc/terms/eventDate), [year](http://rs.tdwg.org/dwc/terms/year), [month](http://rs.tdwg.org/dwc/terms/month), [day](http://rs.tdwg.org/dwc/terms/day) |  dwc:eventDate may represent a range, values of dwc:year dwc:month, and dwc:day are not defined in this case. |
 | CONCISTENCY_LOCATION| [countryCode](http://rs.tdwg.org/dwc/terms/countryCode), [decimalLongitude](http://rs.tdwg.org/dwc/terms/decimalLongitude), [decimalLatitude](http://rs.tdwg.org/dwc/terms/decimalLatitude) |  |
 
 ## 6. Resolution/precision

--- a/dimensions-and-criteria.md
+++ b/dimensions-and-criteria.md
@@ -28,6 +28,7 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 | --- | ----- | -------- |
 | COMPLETION_OCCURRENCE_ID | `occurrenceID` |  |
 | COMPLETION_OCCURRENCE_EVENT_DATE | `eventDate` or `year`, `month`, `day` |  |
+| COMPLETION_BASIS_OF_RECORD | `dwc:basisOfRecord` |  |
 
 ## 2. Integrity
 
@@ -48,11 +49,11 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 
 ### 2.3 Controlled vocabulary
 
-*Controlled vocabulary* defines if a value is present in a list of predefined acceptable values. The options to handle empty/missing values and case-sensitivity is up to the implementation.
+*Controlled vocabulary* defines whether a value is present in a list of predefined acceptable values.  Missing values should be treated as a separate Completeness test.  Case-sensitivity is up to the definition in the vocabulary, which will generally be case sensitive.  Support for fully qualified term names (e.g. http://rs.tdwg.org/dwc/terms/PreservedSpecimen) or short names (e.g. PreservedSpecimen) MAY BE left to the implementation.
  
 | ID | Terms | Comments |
 | ---|------ | -------- |
-| INTEGRITY_CTRL_VOCAB_BASIS_OF_RECORD | [basisOfRecord](http://rs.tdwg.org/dwc/terms/basisOfRecord) |  |
+| INTEGRITY_CTRL_VOCAB_BASIS_OF_RECORD | [basisOfRecord](http://rs.tdwg.org/dwc/terms/basisOfRecord) | Terms in the old [Darwin Core Type Vocabulary](http://rs.gbif.org/vocabulary/dwc/basis_of_record.xml) are in widespread use, and the string constants (e.g. PreservedSpecimen) therein are appropriate, though the namespace has changed. See: Darwin Core documentation [Decision-2009-12-07_2](http://rs.tdwg.org/dwc/terms/history/decisions/#Decision-2009-12-07_2) and [Decision-2014-10-26_15](http://rs.tdwg.org/dwc/terms/history/decisions/#Decision-2014-10-26_15) |
 
 
 ### 2.4 Minimum/maximum

--- a/dimensions-and-criteria.md
+++ b/dimensions-and-criteria.md
@@ -43,9 +43,9 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 
 ### 2.2 Referential integrity
 
-| Terms | Reference | Scope |
-| ------------- | ------------- |------------- |
-| `parentNameUsageID` | `taxonID` | [Taxon](http://rs.tdwg.org/dwc/terms/Taxon) dataset |
+| Terms | Reference | Scope | Comment |
+| ----_ | --------- | ----- | ------- |
+| `parentNameUsageID` | `taxonID` | [Taxon](http://rs.tdwg.org/dwc/terms/Taxon) dataset | Note, this would not be expected to hold if dwc:taxonID was an identifier specific to the dataset, and the ...NameUsageID values were external identifiers. |
 
 ### 2.3 Controlled vocabulary
 


### PR DESCRIPTION
ISSUE: PURPOSE: Clarify Controled Vocabulary text and example. DESCRIPTION: Adding discussion of values of dwc:basisOfRecord.  Noting that presence/absence of controled vocabulary terms should be a completeness test, not an integrity test.  Noting that case sensitivity is defined by the vocabulary, not the test.  Adding an example completeness test for dwc:basisOfRecord.
