### PR TITLE
Referenential integrity example isn't a good one, relates a taxon to a usage, wouldn't actually expect integrity here.

### DIFF
--- a/dimensions-and-criteria.md
+++ b/dimensions-and-criteria.md
@@ -42,9 +42,9 @@ This page lists dimensions and criteria that could eventually be (re)used to cre
 
 ### 2.2 Referential integrity
 
-| Terms | Reference | Scope |
-| ------------- | ------------- |------------- |
-| `parentNameUsageID` | `taxonID` | [Taxon](http://rs.tdwg.org/dwc/terms/Taxon) dataset |
+| Terms | Reference | Scope | Comment |
+| ----_ | --------- | ----- | ------- |
+| `parentNameUsageID` | `taxonID` | [Taxon](http://rs.tdwg.org/dwc/terms/Taxon) dataset | Note, this would not be expected to hold if dwc:taxonID was an identifier specific to the dataset, and the ...NameUsageID values were external identifiers. |
 
 ### 2.3 Controlled vocabulary
 


### PR DESCRIPTION
ISSUE: PURPOSE: Comment on referential integrity test. DESCRIPTION: Noting that taxonID - parentNameUsageID would be reasonably expected not to have referential integrity when the taxonID is local and the other taxon ID pointers are to external resources, which would actually be my normal expectation.
